### PR TITLE
Optimize key formatting

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -182,8 +182,8 @@ class Jbuilder
     @attributes << _scope { yield self }
   end
 
-  # Turns the current element into an array and iterates over the passed collection, adding each iteration as
-  # an element of the resulting array.
+  # Turns the current element into an array and iterates over the passed collection, adding each
+  # iteration as an element of the resulting array.
   #
   # Example:
   #
@@ -198,7 +198,8 @@ class Jbuilder
   #
   #   json.(@people) { |person| ... }
   #
-  # It's generally only needed to use this method for top-level arrays. If you have named arrays, you can do:
+  # It's generally only needed to use this method for top-level arrays. If you have named arrays,
+  # you can do:
   #
   #   json.people(@people) do |person|
   #     json.name person.name
@@ -227,7 +228,8 @@ class Jbuilder
     @attributes = _merge_values(@attributes, array)
   end
 
-  # Extracts the mentioned attributes or hash elements from the passed object and turns them into attributes of the JSON.
+  # Extracts the mentioned attributes or hash elements from the passed object and turns them into
+  # attributes of the JSON.
   #
   # Example:
   #
@@ -333,7 +335,7 @@ class Jbuilder
   def _set_value(key, value)
     ::Kernel.raise NullError.build(key) if @attributes.nil?
     ::Kernel.raise ArrayError.build(key) if ::Array === @attributes
-    return if (@ignore_nil && value.nil?) or _blank?(value)
+    return if (@ignore_nil && value.nil?) || _blank?(value)
 
     @attributes = {} if _blank?
     @attributes[_key(key)] = value
@@ -363,7 +365,7 @@ class Jbuilder
   end
 
   def _blank?(value = @attributes)
-    BLANK == value
+    value == BLANK
   end
 
   def _object_respond_to?(object, *methods)

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -317,7 +317,7 @@ class Jbuilder
   end
 
   def _key(key)
-    @key_formatter ? @key_formatter.format(key) : key.to_s
+    @key_formatter.nil? ? key.name : @key_formatter.format(key)
   end
 
   def _format_keys(hash_or_array)


### PR DESCRIPTION
An optimization to prevent allocating a new string for each key in the json response. Prior to this change,
```ruby
json.set! :foo, 'bar'
```

would allocate a string for `foo` on every render. By using `Symbol#name`, it will instead use the frozen interned string which saves on that extra memory allocation.

```ruby
my_symbol = :foo

Benchmark.memory do |x|
  x.report('Symbol#name') { 100.times { my_symbol.name } }
  x.report('Symbol#to_s') { 100.times { my_symbol.to_s } }

  x.compare!
end
```

```
Calculating -------------------------------------
         Symbol#name     0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
         Symbol#to_s     4.000k memsize (     0.000  retained)
                       100.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
         Symbol#name:          0 allocated
         Symbol#to_s:       4000 allocated - Infx more
```

Using `name` is also more performant

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
         Symbol#name     2.300M i/100ms
         Symbol#to_s     1.318M i/100ms
Calculating -------------------------------------
         Symbol#name     40.122M (± 1.3%) i/s   (24.92 ns/i) -    202.358M in   5.044457s
         Symbol#to_s     17.681M (± 2.3%) i/s   (56.56 ns/i) -     89.620M in   5.071414s

Comparison:
         Symbol#name: 40121894.9 i/s
         Symbol#to_s: 17681248.1 i/s - 2.27x  slower
```