### PR TITLE
Optimize `method_missing` to be nearly on par with `set!` method

### DIFF
--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -64,14 +64,6 @@ class Jbuilder
     _set_value key, result
   end
 
-  def method_missing(*args, &block)
-    if ::Kernel.block_given?
-      set!(*args, &block)
-    else
-      set!(*args)
-    end
-  end
-
   # Specifies formatting to be applied to the key. Passing in a name of a function
   # will cause that function to be called on the key.  So :upcase will upper case
   # the key.  You can also pass in lambdas for more complex transformations.
@@ -280,6 +272,16 @@ class Jbuilder
   end
 
   private
+
+  def method_missing(key, *args, &block)
+    ::Jbuilder.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+      def #{key.name}(...)
+        set!(:#{key.name}, ...)
+      end
+    RUBY
+
+    set!(key, *args, &block)
+  end
 
   def _extract_hash_values(object, attributes)
     attributes.each{ |key| _set_value key, _format_keys(object.fetch(key)) }


### PR DESCRIPTION
`jbuilder` provides a nice DSL where something like

```ruby
json.foo :foo
```

is simply sugar for the `set!` API

```ruby
json.set! :foo, :foo
```

The sugar doesn't come for free, though; `set!` performs substantially better in both CPU and memory. Consider the following benchmark:

```ruby
json = Jbuilder.new
name = 'John Doe'

Benchmark.ips do |x|
  x.report('method_missing') { json.name name }
  x.report('set!') { json.set! :name, name }
  x.compare!
end

Benchmark.memory do |x|
  x.report('method_missing') { json.name name }
  x.report('set!') { json.set! :name, name }
  x.compare!
end
```

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
      method_missing   293.497k i/100ms
                set!   481.601k i/100ms
Calculating -------------------------------------
      method_missing      3.694M (± 2.1%) i/s  (270.70 ns/i) -     18.490M in   5.007609s
                set!      5.426M (± 1.6%) i/s  (184.31 ns/i) -     27.451M in   5.060849s

Comparison:
                set!:  5425603.3 i/s
      method_missing:  3694079.2 i/s - 1.47x  slower
```
```
Calculating -------------------------------------
      method_missing   120.000  memsize (     0.000  retained)
                         3.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)
                set!    80.000  memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
                set!:         80 allocated
      method_missing:        120 allocated - 1.50x more
```

It's around 1.5x slower to use the DSL over `set!`! The main culprit for this is the overhead inherent in `method_missing`. The DSL also results in an additional memory allocation to allocate for `*args`, which is just passed off to set. This can easily be solved by simply using `alias_method :method_missing, :set!`, but that does not solve the above performance problems inherent with `method_missing`.

What this PR does is define a new method on `JBuilder` whenever `method_missing` runs for a key. This results in any subsequent calls to the same key to instead be run as a compiled method, rather than through `method_missing`.

The before after comparison 

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
              before   305.727k i/100ms
               after   457.179k i/100ms
Calculating -------------------------------------
              before      2.981M (± 9.1%) i/s  (335.47 ns/i) -     14.981M in   5.088107s
               after      5.135M (± 1.5%) i/s  (194.72 ns/i) -     26.059M in   5.075481s

Comparison:
               after:  5135476.5 i/s
              before:  2980895.8 i/s - 1.72x  slower
```

```
Calculating -------------------------------------
              before   120.000  memsize (     0.000  retained)
                         3.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)
               after    80.000  memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
               after:         80 allocated
              before:        120 allocated - 1.50x more
```

Final comparison

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
      method_missing   460.531k i/100ms
                set!   487.201k i/100ms
Calculating -------------------------------------
      method_missing      5.116M (± 1.5%) i/s  (195.46 ns/i) -     25.790M in   5.042097s
                set!      5.412M (± 1.2%) i/s  (184.78 ns/i) -     27.283M in   5.042155s

Comparison:
                set!:  5411792.5 i/s
      method_missing:  5116007.9 i/s - 1.06x  slower
```

```
Calculating -------------------------------------
      method_missing    80.000  memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)
                set!    80.000  memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
      method_missing:         80 allocated
                set!:         80 allocated - same
```

This gets the DSL to be nearly on par with a regular `set!` call. It also saves on the allocation when it's called because the parameters are just passed through with `...`.

The tradeoff is that the _first_ time `method_missing` is hit for a key things will be slower, because Ruby has to parse the  new Ruby code at runtime.