### PR TITLE
Optimize `partial!` DSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 tmp
-/log
+**/log
 gemfiles/.bundle
 gemfiles/*.lock
 Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ gemspec
 gem "rake"
 gem "mocha", require: false
 gem "appraisal"
+gem 'benchmark-ips', require: false
+gem 'benchmark-memory', require: false

--- a/benchmarks/partials/partial_dsl.rb
+++ b/benchmarks/partials/partial_dsl.rb
@@ -29,13 +29,15 @@ Benchmark.ips do |x|
   x.compare!
 end
 
+json = JbuilderTemplate.new view
+
 Benchmark.memory do |x|
   x.report('before') do
-    100.times { json.partial! "post", post: post }
+    json.partial! "post", post: post
   end
 
   x.report('after') do
-    100.times { json.partial! "post", post: post }
+    json.partial! "post", post: post
   end
 
   x.hold! 'temp_partial_results_memory'

--- a/benchmarks/partials/partial_dsl.rb
+++ b/benchmarks/partials/partial_dsl.rb
@@ -1,0 +1,41 @@
+require 'benchmark/ips'
+require 'benchmark/memory'
+require_relative 'setup'
+
+POST_PARTIAL = <<-JBUILDER
+  json.extract! post, :id, :body
+JBUILDER
+
+PARTIALS = { "_post.json.jbuilder" => POST_PARTIAL }
+
+Post = Struct.new(:id, :body)
+
+view = build_view(fixtures: PARTIALS)
+json = JbuilderTemplate.new view
+post = Post.new(1, "Post ##{1}")
+
+Benchmark.ips do |x|
+  x.report('before') do |times|
+    times.times { json.partial! "post", post: post }
+  end
+
+  x.report('after') do |times|
+    times.times { json.partial! "post", post: post }
+  end
+
+  x.hold! 'temp_partial_results_ips'
+  x.compare!
+end
+
+Benchmark.memory do |x|
+  x.report('before') do
+    100.times { json.partial! "post", post: post }
+  end
+
+  x.report('after') do
+    100.times { json.partial! "post", post: post }
+  end
+
+  x.hold! 'temp_partial_results_memory'
+  x.compare!
+end

--- a/benchmarks/partials/partial_dsl.rb
+++ b/benchmarks/partials/partial_dsl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/ips'
 require 'benchmark/memory'
 require_relative 'setup'

--- a/benchmarks/partials/setup.rb
+++ b/benchmarks/partials/setup.rb
@@ -1,0 +1,30 @@
+require "rails"
+require "active_support/core_ext/array/access"
+require "active_support/cache/memory_store"
+require "active_support/json"
+require "active_model"
+require 'action_controller/railtie'
+require 'action_view/railtie'
+require "active_support/testing/autorun"
+require "action_view/testing/resolvers"
+require_relative '../../lib/jbuilder'
+require_relative '../../lib/jbuilder/jbuilder_template'
+
+# A lot of this was copied over from the `jbuilder_template_test.rb` file.
+
+# Instantiate an Application in order to trigger the initializers
+Class.new(Rails::Application) do
+  config.secret_key_base = 'secret'
+  config.eager_load = false
+end.initialize!
+
+# # Touch AV::Base in order to trigger :action_view on_load hook before running the tests
+ActionView::Base.inspect
+
+def build_view(fixtures:, assigns: {})
+  resolver = ActionView::FixtureResolver.new(fixtures)
+  lookup_context = ActionView::LookupContext.new([ resolver ], {}, [""])
+  controller = ActionView::TestCase::TestController.new
+
+  ActionView::Base.with_empty_template_cache.new(lookup_context, assigns, controller)
+end

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -50,7 +50,7 @@ class JbuilderTemplate < Jbuilder
   #   json.comments @post.comments, partial: "comments/comment", as: :comment, cached: true
   #
   def partial!(partial_or_model = nil, **options)
-    if partial_or_model && _is_active_model?(partial_or_model)
+    if partial_or_model.class.respond_to?(:model_name) && partial_or_model.respond_to?(:to_partial_path)
       _render_active_model_partial partial_or_model
     else
       options[:partial] = partial_or_model if partial_or_model
@@ -221,10 +221,6 @@ class JbuilderTemplate < Jbuilder
 
   def _partial_options?(options)
     ::Hash === options && options.key?(:as) && options.key?(:partial)
-  end
-
-  def _is_active_model?(object)
-    object.class.respond_to?(:model_name) && object.respond_to?(:to_partial_path)
   end
 
   def _set_inline_partial(name, object, options)

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -144,12 +144,12 @@ class JbuilderTemplate < Jbuilder
   def _render_partial_with_options(options)
     options[:locals] ||= options.except(:partial, :as, :collection, :cached)
     options[:handlers] ||= ::JbuilderTemplate.template_lookup_options[:handlers]
+    options[:locals][:json] = self
     as = options[:as]
 
     if as && options.key?(:collection)
       collection = options.delete(:collection) || []
       partial = options.delete(:partial)
-      options[:locals][:json] = self
       collection = EnumerableCompat.new(collection) if collection.respond_to?(:count) && !collection.respond_to?(:size)
 
       if options.has_key?(:layout)
@@ -170,13 +170,9 @@ class JbuilderTemplate < Jbuilder
         array!
       end
     else
-      _render_partial options
+      # Prevents memory allocation for an empty Hash by providing nil as the second argument.
+      @context.render options, nil
     end
-  end
-
-  def _render_partial(options)
-    options[:locals][:json] = self
-    @context.render options, nil
   end
 
   def _cache_fragment_for(key, options, &block)

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -220,7 +220,7 @@ class JbuilderTemplate < Jbuilder
   end
 
   def _is_active_model?(object)
-    object.class.respond_to?(:model_name) && object.respond_to?(:to_partial_path)
+    object.respond_to?(:to_partial_path) && object.class.respond_to?(:model_name)
   end
 
   def _set_inline_partial(name, object, options)

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -144,12 +144,12 @@ class JbuilderTemplate < Jbuilder
   def _render_partial_with_options(options)
     options[:locals] ||= options.except(:partial, :as, :collection, :cached)
     options[:handlers] ||= ::JbuilderTemplate.template_lookup_options[:handlers]
-    options[:locals][:json] = self
     as = options[:as]
 
     if as && options.key?(:collection)
       collection = options.delete(:collection) || []
       partial = options.delete(:partial)
+      options[:locals][:json] = self
       collection = EnumerableCompat.new(collection) if collection.respond_to?(:count) && !collection.respond_to?(:size)
 
       if options.has_key?(:layout)
@@ -170,9 +170,14 @@ class JbuilderTemplate < Jbuilder
         array!
       end
     else
-      # Prevents memory allocation for an empty Hash by providing nil as the second argument.
-      @context.render options, nil
+      _render_partial options
     end
+  end
+
+  def _render_partial(options)
+    options[:locals][:json] = self
+    # Prevents memory allocation for an empty Hash by providing nil as the second argument.
+    @context.render options, nil
   end
 
   def _cache_fragment_for(key, options, &block)

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -50,7 +50,7 @@ class JbuilderTemplate < Jbuilder
   #   json.comments @post.comments, partial: "comments/comment", as: :comment, cached: true
   #
   def partial!(partial_or_model = nil, **options)
-    if partial_or_model.class.respond_to?(:model_name) && partial_or_model.respond_to?(:to_partial_path)
+    if options.empty? && _is_active_model?(partial_or_model)
       _render_active_model_partial partial_or_model
     else
       options[:partial] = partial_or_model if partial_or_model
@@ -217,6 +217,10 @@ class JbuilderTemplate < Jbuilder
 
   def _partial_options?(options)
     ::Hash === options && options.key?(:as) && options.key?(:partial)
+  end
+
+  def _is_active_model?(object)
+    object.class.respond_to?(:model_name) && object.respond_to?(:to_partial_path)
   end
 
   def _set_inline_partial(name, object, options)

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -49,11 +49,12 @@ class JbuilderTemplate < Jbuilder
   #
   #   json.comments @post.comments, partial: "comments/comment", as: :comment, cached: true
   #
-  def partial!(*args)
-    if args.one? && _is_active_model?(args.first)
-      _render_active_model_partial args.first
+  def partial!(partial_or_model = nil, **options)
+    if partial_or_model && _is_active_model?(partial_or_model)
+      _render_active_model_partial partial_or_model
     else
-      _render_explicit_partial(*args)
+      options[:partial] = partial_or_model if partial_or_model
+      _render_partial_with_options options
     end
   end
 
@@ -120,7 +121,7 @@ class JbuilderTemplate < Jbuilder
 
     if args.one? && _partial_options?(options)
       options[:collection] = collection
-      partial! options
+      _render_partial_with_options options
     else
       super
     end
@@ -243,28 +244,6 @@ class JbuilderTemplate < Jbuilder
     end
 
     _set_value name, value
-  end
-
-  def _render_explicit_partial(name_or_options, locals = {})
-    case name_or_options
-    when ::Hash
-      # partial! partial: 'name', foo: 'bar'
-      options = name_or_options
-    else
-      # partial! 'name', locals: {foo: 'bar'}
-      if locals.one? && (locals.keys.first == :locals)
-        locals[:partial] = name_or_options
-        options = locals
-      else
-        options = { partial: name_or_options, locals: locals }
-      end
-      # partial! 'name', foo: 'bar'
-      as = locals.delete(:as)
-      options[:as] = as if as.present?
-      options[:collection] = locals[:collection] if locals.key?(:collection)
-    end
-
-    _render_partial_with_options options
   end
 
   def _render_active_model_partial(object)


### PR DESCRIPTION
Addressing some hotspots we're seeing in our profiling. Instead of doing a full context dump here, I'll annotate the points of interest below.

Note on the benchmarks:
- When it comes to running `jbuilder` that need partials, a lot more needs to be setup with `actionview`. This results in _more stuff_ running under the benchmark, which dilutes the measurement. I did my best to come get a minimal setup. I'm sure there are ways to lean it out more, but it's a lot to figure out.
- The IPS benchmarks might not look super convincing, but these _do_ come up as hotspots in our profiling. `partial!` can run many, many times per template render, and it's hard to capture this in IPS because the more complex the template is, the fewer times it can run per second, and thus the sample size becomes much smaller.
- For the memory benchmark, I am running the DSL 100 times. I picked that number somewhat arbitrarily, but I want to run it more than once to make the memory optimizations clearer. Something like `partial!` will often run more than once in a given a template, so seeing something that reflects that helps highlight the savings we hope to see.

Compared to the upstream `jbuilder` (ie. the `upstream_main` branch). This compares all of our optimizations done so far against "stock" `jbuilder`.

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
              before     6.437k i/100ms
               after     6.917k i/100ms
Calculating -------------------------------------
              before     70.077k (± 3.6%) i/s   (14.27 μs/i) -    354.035k in   5.058645s
               after     76.812k (± 5.3%) i/s   (13.02 μs/i) -    387.352k in   5.057574s

Comparison:
               after:    76812.1 i/s
              before:    70076.6 i/s - 1.10x  slower
```

```
Calculating -------------------------------------
              before   419.200k memsize (     0.000  retained)
                         4.800k objects (     0.000  retained)
                        11.000  strings (     0.000  retained)
               after   303.200k memsize (     0.000  retained)
                         3.700k objects (     0.000  retained)
                         9.000  strings (     0.000  retained)

Comparison:
               after:     303200 allocated
              before:     419200 allocated - 1.38x more
```

Compared to `main`, which includes all of our other optimizations already. This more closely reflects the impact this optimization has compared to what we're currently running.

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
              before     6.991k i/100ms
               after     7.327k i/100ms
Calculating -------------------------------------
              before     70.618k (± 4.2%) i/s   (14.16 μs/i) -    356.541k in   5.058201s
               after     75.337k (± 4.2%) i/s   (13.27 μs/i) -    381.004k in   5.065986s

Comparison:
               after:    75336.8 i/s
              before:    70618.2 i/s - same-ish: difference falls within error
```

```
Calculating -------------------------------------
              before   315.200k memsize (     0.000  retained)
                         4.000k objects (     0.000  retained)
                         9.000  strings (     0.000  retained)
               after   303.200k memsize (     0.000  retained)
                         3.700k objects (     0.000  retained)
                         9.000  strings (     0.000  retained)

Comparison:
               after:     303200 allocated
              before:     315200 allocated - 1.04x more
```

(I will include the benchmarks in this PR soon-ish... just want to clean it up first so that it doesn't look like nonsense.)