### PR TITLE
Add `#frozen_string_literal: true` to all files

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 appraise "rails-7-0" do
   gem "rails", "~> 7.0.0"
   gem "concurrent-ruby", "< 1.3.5" # to avoid problem described in https://github.com/rails/rails/pull/54264

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 require "bundler/gem_tasks"
 require "rake/testtask"

--- a/jbuilder.gemspec
+++ b/jbuilder.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lib/jbuilder/version"
 
 Gem::Specification.new do |s|

--- a/lib/generators/rails/jbuilder_generator.rb
+++ b/lib/generators/rails/jbuilder_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails/generators/named_base'
 require 'rails/generators/resource_helpers'
 

--- a/lib/generators/rails/scaffold_controller_generator.rb
+++ b/lib/generators/rails/scaffold_controller_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails/generators'
 require 'rails/generators/rails/scaffold_controller/scaffold_controller_generator'
 

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support'
 require 'jbuilder/jbuilder'
 require 'jbuilder/blank'

--- a/lib/jbuilder/blank.rb
+++ b/lib/jbuilder/blank.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Jbuilder
   class Blank
     def ==(other)

--- a/lib/jbuilder/collection_renderer.rb
+++ b/lib/jbuilder/collection_renderer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'delegate'
 require 'active_support/concern'
 require 'action_view'

--- a/lib/jbuilder/errors.rb
+++ b/lib/jbuilder/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'jbuilder/jbuilder'
 
 class Jbuilder

--- a/lib/jbuilder/jbuilder.rb
+++ b/lib/jbuilder/jbuilder.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 Jbuilder = Class.new(BasicObject)

--- a/lib/jbuilder/jbuilder_dependency_tracker.rb
+++ b/lib/jbuilder/jbuilder_dependency_tracker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Jbuilder::DependencyTracker
   EXPLICIT_DEPENDENCY = /# Template Dependency: (\S+)/
 

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'jbuilder/jbuilder'
 require 'jbuilder/collection_renderer'
 require 'action_dispatch/http/mime_type'

--- a/lib/jbuilder/key_formatter.rb
+++ b/lib/jbuilder/key_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'jbuilder/jbuilder'
 require 'active_support/core_ext/array'
 

--- a/lib/jbuilder/railtie.rb
+++ b/lib/jbuilder/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails'
 require 'jbuilder/jbuilder_template'
 

--- a/lib/jbuilder/version.rb
+++ b/lib/jbuilder/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Jbuilder
   VERSION = "2.13.0"
 end


### PR DESCRIPTION
Simply adds `#frozen_string_literal: true` to all files. No idea why these were missing. Don't think this will make a huge difference, but it can't hurt.

Are these necessary/useful for `Rakefile`, `Gemfile`, etc?

~This is another easy one that can be easily filed upstream.~ Done: https://github.com/rails/jbuilder/pull/599