### PR TITLE
Optimize `array!` DSL

### DIFF
--- a/benchmarks/jbuilder/set_dsl_array_block.rb
+++ b/benchmarks/jbuilder/set_dsl_array_block.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'benchmark/memory'
+require_relative '../../lib/jbuilder'
+
+Post = Struct.new(:id, :body)
+json = Jbuilder.new
+posts = 3.times.map { Post.new(it, "Post ##{it}") }
+
+Benchmark.ips do |x|
+  x.report('before') do
+    json.set! :posts, posts do |post|
+      json.extract! post, :id, :body
+    end
+  end
+  x.report('after') do
+    json.set! :posts, posts do |post|
+      json.extract! post, :id, :body
+    end
+  end
+
+  x.hold! 'temp_array_ips'
+  x.compare!
+end
+
+json = Jbuilder.new
+
+Benchmark.memory do |x|
+  x.report('before') do
+    json.set! :posts, posts do |post|
+      json.extract! post, :id, :body
+    end
+  end
+  x.report('after') do
+    json.set! :posts, posts do |post|
+      json.extract! post, :id, :body
+    end
+  end
+
+  x.hold! 'temp_array_memory'
+  x.compare!
+end

--- a/benchmarks/jbuilder/set_dsl_extract_array.rb
+++ b/benchmarks/jbuilder/set_dsl_extract_array.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'benchmark/memory'
+require_relative '../../lib/jbuilder'
+
+Post = Struct.new(:id, :body)
+json = Jbuilder.new
+posts = 3.times.map { Post.new(it, "Post ##{it}") }
+
+Benchmark.ips do |x|
+  x.report('before') do
+    json.set! :posts, posts, :id, :body
+  end
+  x.report('after') do
+    json.set! :posts, posts, :id, :body
+  end
+
+  x.hold! 'temp_array_ips'
+  x.compare!
+end
+
+json = Jbuilder.new
+
+Benchmark.memory do |x|
+  x.report('before') do
+    json.set! :posts, posts, :id, :body
+  end
+  x.report('after') do
+    json.set! :posts, posts, :id, :body
+  end
+
+  x.hold! 'temp_array_memory'
+  x.compare!
+end

--- a/benchmarks/jbuilder_template/array_dsl.rb
+++ b/benchmarks/jbuilder_template/array_dsl.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'benchmark/memory'
+require_relative '../../lib/jbuilder'
+require_relative '../../lib/jbuilder/jbuilder_template'
+
+Post = Struct.new(:id, :body)
+json = JbuilderTemplate.new nil
+posts = 3.times.map { Post.new(it, "Post ##{it}") }
+
+Benchmark.ips do |x|
+  x.report('before') do
+    json.array!(nil)
+  end
+  x.report('after') do
+    json.array!(nil)
+  end
+
+  x.hold! 'temp_array_ips'
+  x.compare!
+end
+
+json = JbuilderTemplate.new nil
+
+Benchmark.memory do |x|
+  x.report('before') { json.array! posts, :id, :body }
+  x.report('after') { json.array! posts, :id, :body }
+
+  x.hold! 'temp_array_memory'
+  x.compare!
+end

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -207,7 +207,7 @@ class Jbuilder
   #   json.array! [1, 2, 3]
   #
   #   [1,2,3]
-  def array!(collection = [], *attributes, &block)
+  def array!(collection = nil, *attributes, &block)
     _array(collection, attributes, &block)
   end
 

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -33,7 +33,8 @@ class Jbuilder
     new(*args, &block).target!
   end
 
-  BLANK = Blank.new
+  BLANK = Blank.new.freeze
+  EMPTY_ARRAY = [].freeze
 
   def set!(key, value = BLANK, *args, &block)
     result = if ::Kernel.block_given?
@@ -207,7 +208,7 @@ class Jbuilder
   #   json.array! [1, 2, 3]
   #
   #   [1,2,3]
-  def array!(collection = nil, *attributes, &block)
+  def array!(collection = EMPTY_ARRAY, *attributes, &block)
     _array(collection, attributes, &block)
   end
 
@@ -267,12 +268,12 @@ class Jbuilder
 
   alias_method :method_missing, :set!
 
-  def _array(collection, attributes, &block)
+  def _array(collection = EMPTY_ARRAY, attributes = nil, &block)
     array = if collection.nil?
-      []
+      EMPTY_ARRAY
     elsif block
       _map_collection(collection, &block)
-    elsif !attributes.empty?
+    elsif attributes.present?
       _map_collection(collection) { |element| _extract element, attributes }
     else
       _format_keys(collection.to_a)

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -208,17 +208,7 @@ class Jbuilder
   #
   #   [1,2,3]
   def array!(collection = [], *attributes, &block)
-    array = if collection.nil?
-      []
-    elsif ::Kernel.block_given?
-      _map_collection(collection, &block)
-    elsif attributes.any?
-      _map_collection(collection) { |element| _extract element, attributes }
-    else
-      _format_keys(collection.to_a)
-    end
-
-    @attributes = _merge_values(@attributes, array)
+    _array(collection, attributes, &block)
   end
 
   # Extracts the mentioned attributes or hash elements from the passed object and turns them into attributes of the JSON.
@@ -276,6 +266,20 @@ class Jbuilder
   private
 
   alias_method :method_missing, :set!
+
+  def _array(collection, attributes, &block)
+    array = if collection.nil?
+      []
+    elsif block
+      _map_collection(collection, &block)
+    elsif !attributes.empty?
+      _map_collection(collection) { |element| _extract element, attributes }
+    else
+      _format_keys(collection.to_a)
+    end
+
+    @attributes = _merge_values(@attributes, array)
+  end
 
   def _extract(object, attributes)
     if ::Hash === object

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -35,6 +35,7 @@ class Jbuilder
 
   BLANK = Blank.new.freeze
   EMPTY_ARRAY = [].freeze
+  private_constant :BLANK, :EMPTY_ARRAY
 
   def set!(key, value = BLANK, *args, &block)
     result = if ::Kernel.block_given?

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -8,6 +8,7 @@ require 'jbuilder/errors'
 require 'jbuilder/version'
 require 'json'
 require 'active_support/core_ext/hash/deep_merge'
+require 'active_support/core_ext/object/blank'
 
 class Jbuilder
   @@key_formatter = nil

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -41,7 +41,7 @@ class Jbuilder
       if !_blank?(value)
         # json.comments @post.comments { |comment| ... }
         # { "comments": [ { ... }, { ... } ] }
-        _scope{ array! value, &block }
+        _scope{ _array value, &block }
       else
         # json.comments { ... }
         # { "comments": ... }
@@ -61,7 +61,7 @@ class Jbuilder
     elsif _is_collection?(value)
       # json.comments @post.comments, :content, :created_at
       # { "comments": [ { "content": "hello", "created_at": "..." }, { "content": "world", "created_at": "..." } ] }
-      _scope{ array! value, *args }
+      _scope{ _array value, args }
     else
       # json.author @post.creator, :name, :email_address
       # { "author": { "name": "David", "email_address": "david@loudthinking.com" } }
@@ -235,7 +235,7 @@ class Jbuilder
 
   def call(object, *attributes, &block)
     if ::Kernel.block_given?
-      array! object, &block
+      _array object, &block
     else
       _extract object, attributes
     end

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -118,14 +118,14 @@ class JbuilderTemplate < Jbuilder
     @cached_root || super
   end
 
-  def array!(collection = [], *args)
-    options = args.first
-
-    if args.one? && _partial_options?(options)
+  def array!(collection = [], *attributes, partial: nil, as: nil, **options)
+    if as && partial
       options[:collection] = collection
+      options[:partial] = partial
+      options[:as] = as
       _render_partial_with_options options
     else
-      super
+      _array collection, attributes
     end
   end
 

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -118,7 +118,7 @@ class JbuilderTemplate < Jbuilder
     @cached_root || super
   end
 
-  def array!(collection = nil, *args, &block)
+  def array!(collection = EMPTY_ARRAY, *args, &block)
     options = args.first
 
     if _partial_options?(options)
@@ -167,9 +167,9 @@ class JbuilderTemplate < Jbuilder
           .new(@context.lookup_context, options) { |&block| _scope(&block) }
           .render_collection_with_partial(collection, partial, @context, nil)
 
-        array! if results.respond_to?(:body) && results.body.nil?
+        _array if results.respond_to?(:body) && results.body.nil?
       else
-        array!
+        _array
       end
     else
       _render_partial options

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -149,7 +149,7 @@ class JbuilderTemplate < Jbuilder
     as = options[:as]
 
     if as && options.key?(:collection)
-      collection = options.delete(:collection) || []
+      collection = options.delete(:collection) || EMPTY_ARRAY
       partial = options.delete(:partial)
       options[:locals][:json] = self
       collection = EnumerableCompat.new(collection) if collection.respond_to?(:count) && !collection.respond_to?(:size)
@@ -232,7 +232,7 @@ class JbuilderTemplate < Jbuilder
 
   def _set_inline_partial(name, object, options)
     value = if object.nil?
-      []
+      EMPTY_ARRAY
     elsif _is_collection?(object)
       _scope do
         options[:collection] = object

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -118,7 +118,7 @@ class JbuilderTemplate < Jbuilder
     @cached_root || super
   end
 
-  def array!(collection = [], *args, &block)
+  def array!(collection = nil, *args, &block)
     options = args.first
 
     if _partial_options?(options)

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -118,14 +118,14 @@ class JbuilderTemplate < Jbuilder
     @cached_root || super
   end
 
-  def array!(collection = [], *attributes, partial: nil, as: nil, **options)
-    if as && partial
+  def array!(collection = [], *args, &block)
+    options = args.first
+
+    if _partial_options?(options)
       options[:collection] = collection
-      options[:partial] = partial
-      options[:as] = as
       _render_partial_with_options options
     else
-      _array collection, attributes
+      _array collection, args, &block
     end
   end
 


### PR DESCRIPTION
This optimizes the `array!` DSL to run faster with less memory usage. The PR may look a bit bigger than it actually is, but a summary of the changes:
- Save on a call to `one?`. This shows up as a hotspot for us, and it isn't actually needed. The intent here was to check if a single argument was provided to `array!` to determine whether or not a partial should be rendered. It's actually just faster to check if the first argument is a `Hash` than it is to call out to `one?` first, because the latter is an O(n) operation.
- Save on calls to `::Kernel.block_given?`. Because `Jbuilder` is a `BasicObject`, it does not have direct access to `block_given?`, so it must explicitly call out to the `Kernel` module instead. This is actually slower than simply explicitly checking if the `block` argument exists.
- Saves on memory allocations originally caused by internal calls to `array!`, which splats `*args` into an allocated `Array` each time. The PR introduces `_array` to be used internally, which saves on this allocation. This is similar to what was done in #7 for `extract!`.
- Introduces a frozen `EMPTY_ARRAY` to save on allocating a new empty array (ie. `[]`) each time an empty collections are rendered.

The leanest way to benchmark the `array!` DSL is with

```ruby
json.array!(nil)
```

This gets the main changes running the most frequently under the benchmark without it being diluted by other things. Results look good so far!

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
              before   491.189k i/100ms
               after   727.930k i/100ms
Calculating -------------------------------------
              before      5.124M (±15.6%) i/s  (195.18 ns/i) -     24.559M in   5.025914s
               after      8.195M (± 7.9%) i/s  (122.03 ns/i) -     40.764M in   5.043596s

Comparison:
               after:  8194919.7 i/s
              before:  5123561.6 i/s - 1.60x  slower
```

```
Calculating -------------------------------------
              before   832.000  memsize (   520.000  retained)
                         8.000  objects (     4.000  retained)
                         0.000  strings (     0.000  retained)
               after   640.000  memsize (   520.000  retained)
                         7.000  objects (     4.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
               after:        640 allocated
              before:        832 allocated - 1.30x more
```

There are a few other spots that are now also taking advantage of these optimizations. Those have been annotated below.

Please note that all benchmarks are being compared to our fork's `main` branch, so they capture the differences introduced by this PR. If you like, I can also include benchmarks against `upstream_main` to show how _all_ of our optimizations compare to stock `jbuilder` thus far.

(Still poking around the benchmarks. I will include them in the PR soon.)