### PR TITLE
Optimize `set!` DSL

### DIFF
--- a/benchmarks/jbuilder_template/set_dsl.rb
+++ b/benchmarks/jbuilder_template/set_dsl.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'benchmark/memory'
+require_relative '../../lib/jbuilder'
+require_relative '../../lib/jbuilder/jbuilder_template'
+
+json = JbuilderTemplate.new nil
+
+Benchmark.ips do |x|
+  x.report('before') do |n|
+    n.times { json.set! :foo, :bar }
+  end
+  x.report('after') do |n|
+    n.times { json.set! :foo, :bar }
+  end
+
+  x.hold! 'temp_set_ips'
+  x.compare!
+end
+
+json = JbuilderTemplate.new nil
+
+Benchmark.memory do |x|
+  x.report('before') { json.set! :foo, :bar }
+  x.report('after') { json.set! :foo, :bar }
+
+  x.hold! 'temp_set_memory'
+  x.compare!
+end

--- a/benchmarks/jbuilder_template/set_dsl_array_block.rb
+++ b/benchmarks/jbuilder_template/set_dsl_array_block.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'benchmark/memory'
+require_relative '../../lib/jbuilder'
+require_relative '../../lib/jbuilder/jbuilder_template'
+
+json = JbuilderTemplate.new nil
+array = [1, 2, 3]
+
+Benchmark.ips do |x|
+  x.report('before') do |n|
+    n.times do
+      json.set! :foo, array do |item|
+        json.set! :bar, item
+      end
+    end
+  end
+  x.report('after') do |n|
+    n.times do
+      json.set! :foo, array do |item|
+        json.set! :bar, item
+      end
+    end
+  end
+
+  x.hold! 'temp_set_ips'
+  x.compare!
+end
+
+json = JbuilderTemplate.new nil
+
+Benchmark.memory do |x|
+  x.report('before') do
+    json.set! :foo, array do |item|
+      json.set! :bar, item
+    end
+  end
+  x.report('after') do
+    json.set! :foo, array do |item|
+      json.set! :bar, item
+    end
+  end
+
+  x.hold! 'temp_set_memory'
+  x.compare!
+end

--- a/benchmarks/jbuilder_template/set_dsl_block.rb
+++ b/benchmarks/jbuilder_template/set_dsl_block.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'benchmark/memory'
+require_relative '../../lib/jbuilder'
+require_relative '../../lib/jbuilder/jbuilder_template'
+
+json = JbuilderTemplate.new nil
+object = { bar: 123 }
+
+Benchmark.ips do |x|
+  x.report('before') do |n|
+    n.times do
+      json.set! :foo do
+        json.extract! object, :bar
+      end
+    end
+  end
+  x.report('after') do |n|
+    n.times do
+      json.set! :foo do
+        json.extract! object, :bar
+      end
+    end
+  end
+
+  x.hold! 'temp_set_ips'
+  x.compare!
+end
+
+json = JbuilderTemplate.new nil
+
+Benchmark.memory do |x|
+  x.report('before') do
+    json.set! :foo do
+      json.extract! object, :bar
+    end
+  end
+  x.report('after') do
+    json.set! :foo do
+      json.extract! object, :bar
+    end
+  end
+
+  x.hold! 'temp_set_memory'
+  x.compare!
+end

--- a/benchmarks/partials/set_dsl.rb
+++ b/benchmarks/partials/set_dsl.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'benchmark/memory'
+require_relative 'setup'
+
+POST_PARTIAL = <<-JBUILDER
+  json.extract! post, :id, :body
+JBUILDER
+
+PARTIALS = { "_post.json.jbuilder" => POST_PARTIAL }
+
+Post = Struct.new(:id, :body)
+
+view = build_view(fixtures: PARTIALS)
+json = JbuilderTemplate.new view
+post = Post.new(1, "Post ##{1}")
+
+Benchmark.ips do |x|
+  x.report('before') do |n|
+    n.times { json.set! post, partial: "post", as: :post }
+  end
+
+  x.report('after') do |n|
+    n.times { json.set! post, partial: "post", as: :post }
+  end
+
+  x.hold! 'temp_set_results_ips'
+  x.compare!
+end
+
+json = JbuilderTemplate.new view
+
+Benchmark.memory do |x|
+  x.report('before') do
+    json.set! :post, post, partial: "post", as: :post
+  end
+
+  x.report('after') do
+    json.set! :post, post, partial: "post", as: :post
+  end
+
+  x.hold! 'temp_set_results_memory'
+  x.compare!
+end

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -239,16 +239,16 @@ class Jbuilder
 
   alias_method :method_missing, :set!
 
-  def _set(key, value = BLANK, attributes = nil, &block)
-    result = if block
+  def _set(key, value = BLANK, attributes = nil)
+    result = if ::Kernel.block_given?
       if _blank?(value)
         # json.comments { ... }
         # { "comments": ... }
-        _merge_block(key){ yield self }
+        _merge_block(key) { yield self }
       else
         # json.comments @post.comments { |comment| ... }
         # { "comments": [ { ... }, { ... } ] }
-        _scope{ _array value, &block }
+        _scope { _array(value) { |element| yield element } }
       end
     elsif attributes.blank?
       if ::Jbuilder === value
@@ -264,11 +264,11 @@ class Jbuilder
     elsif _is_collection?(value)
       # json.comments @post.comments, :content, :created_at
       # { "comments": [ { "content": "hello", "created_at": "..." }, { "content": "world", "created_at": "..." } ] }
-      _scope{ _array value, attributes }
+      _scope { _array value, attributes }
     else
       # json.author @post.creator, :name, :email_address
       # { "author": { "name": "David", "email_address": "david@loudthinking.com" } }
-      _merge_block(key){ _extract value, attributes }
+      _merge_block(key) { _extract value, attributes }
     end
 
     _set_value key, result

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -241,14 +241,14 @@ class Jbuilder
 
   def _set(key, value = BLANK, attributes = nil, &block)
     result = if block
-      if !_blank?(value)
-        # json.comments @post.comments { |comment| ... }
-        # { "comments": [ { ... }, { ... } ] }
-        _scope{ _array value, &block }
-      else
+      if _blank?(value)
         # json.comments { ... }
         # { "comments": ... }
         _merge_block(key){ yield self }
+      else
+        # json.comments @post.comments { |comment| ... }
+        # { "comments": [ { ... }, { ... } ] }
+        _scope{ _array value, &block }
       end
     elsif attributes.blank?
       if ::Jbuilder === value

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -39,38 +39,7 @@ class Jbuilder
   private_constant :BLANK, :EMPTY_ARRAY
 
   def set!(key, value = BLANK, *args, &block)
-    result = if ::Kernel.block_given?
-      if !_blank?(value)
-        # json.comments @post.comments { |comment| ... }
-        # { "comments": [ { ... }, { ... } ] }
-        _scope{ _array value, &block }
-      else
-        # json.comments { ... }
-        # { "comments": ... }
-        _merge_block(key){ yield self }
-      end
-    elsif args.empty?
-      if ::Jbuilder === value
-        # json.age 32
-        # json.person another_jbuilder
-        # { "age": 32, "person": { ...  }
-        _format_keys(value.attributes!)
-      else
-        # json.age 32
-        # { "age": 32 }
-        _format_keys(value)
-      end
-    elsif _is_collection?(value)
-      # json.comments @post.comments, :content, :created_at
-      # { "comments": [ { "content": "hello", "created_at": "..." }, { "content": "world", "created_at": "..." } ] }
-      _scope{ _array value, args }
-    else
-      # json.author @post.creator, :name, :email_address
-      # { "author": { "name": "David", "email_address": "david@loudthinking.com" } }
-      _merge_block(key){ _extract value, args }
-    end
-
-    _set_value key, result
+    _set(key, value, args, &block)
   end
 
   # Specifies formatting to be applied to the key. Passing in a name of a function
@@ -269,6 +238,41 @@ class Jbuilder
   private
 
   alias_method :method_missing, :set!
+
+  def _set(key, value = BLANK, attributes, &block)
+    result = if block
+      if !_blank?(value)
+        # json.comments @post.comments { |comment| ... }
+        # { "comments": [ { ... }, { ... } ] }
+        _scope{ _array value, &block }
+      else
+        # json.comments { ... }
+        # { "comments": ... }
+        _merge_block(key){ yield self }
+      end
+    elsif attributes.empty?
+      if ::Jbuilder === value
+        # json.age 32
+        # json.person another_jbuilder
+        # { "age": 32, "person": { ...  }
+        _format_keys(value.attributes!)
+      else
+        # json.age 32
+        # { "age": 32 }
+        _format_keys(value)
+      end
+    elsif _is_collection?(value)
+      # json.comments @post.comments, :content, :created_at
+      # { "comments": [ { "content": "hello", "created_at": "..." }, { "content": "world", "created_at": "..." } ] }
+      _scope{ _array value, attributes }
+    else
+      # json.author @post.creator, :name, :email_address
+      # { "author": { "name": "David", "email_address": "david@loudthinking.com" } }
+      _merge_block(key){ _extract value, attributes }
+    end
+
+    _set_value key, result
+  end
 
   def _array(collection = EMPTY_ARRAY, attributes = nil, &block)
     array = if collection.nil?

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -39,7 +39,7 @@ class Jbuilder
   private_constant :BLANK, :EMPTY_ARRAY
 
   def set!(key, value = BLANK, *args, &block)
-    _set(key, value, args, &block)
+    _set(key, value, args, block)
   end
 
   # Specifies formatting to be applied to the key. Passing in a name of a function
@@ -239,7 +239,7 @@ class Jbuilder
 
   alias_method :method_missing, :set!
 
-  def _set(key, value = BLANK, attributes, &block)
+  def _set(key, value = BLANK, attributes = nil, block = nil)
     result = if block
       if !_blank?(value)
         # json.comments @post.comments { |comment| ... }
@@ -248,7 +248,7 @@ class Jbuilder
       else
         # json.comments { ... }
         # { "comments": ... }
-        _merge_block(key){ yield self }
+        _merge_block key, &block
       end
     elsif attributes.empty?
       if ::Jbuilder === value

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -39,7 +39,7 @@ class Jbuilder
   private_constant :BLANK, :EMPTY_ARRAY
 
   def set!(key, value = BLANK, *args, &block)
-    _set(key, value, args, block)
+    _set(key, value, args, &block)
   end
 
   # Specifies formatting to be applied to the key. Passing in a name of a function
@@ -239,7 +239,7 @@ class Jbuilder
 
   alias_method :method_missing, :set!
 
-  def _set(key, value = BLANK, attributes = nil, block = nil)
+  def _set(key, value = BLANK, attributes = nil, &block)
     result = if block
       if !_blank?(value)
         # json.comments @post.comments { |comment| ... }
@@ -248,7 +248,7 @@ class Jbuilder
       else
         # json.comments { ... }
         # { "comments": ... }
-        _merge_block key, &block
+        _merge_block(key){ yield self }
       end
     elsif attributes.blank?
       if ::Jbuilder === value

--- a/lib/jbuilder.rb
+++ b/lib/jbuilder.rb
@@ -250,7 +250,7 @@ class Jbuilder
         # { "comments": ... }
         _merge_block key, &block
       end
-    elsif attributes.empty?
+    elsif attributes.blank?
       if ::Jbuilder === value
         # json.age 32
         # json.person another_jbuilder

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -135,7 +135,7 @@ class JbuilderTemplate < Jbuilder
     if _partial_options?(options)
       _set_inline_partial name, object, options
     else
-      _set name, object, args, &block
+      _set name, object, args, block
     end
   end
 

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -239,9 +239,8 @@ class JbuilderTemplate < Jbuilder
         _render_partial_with_options options
       end
     else
-      locals = ::Hash[options[:as], object]
       _scope do
-        options[:locals] = locals
+        options[:locals] = { options[:as] => object }
         _render_partial_with_options options
       end
     end

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -134,8 +134,10 @@ class JbuilderTemplate < Jbuilder
 
     if _partial_options?(options)
       _set_inline_partial name, object, options
+    elsif ::Kernel.block_given?
+      _set(name, object, args) { |x| yield x }
     else
-      ::Kernel.block_given? ? super : _set(name, object, args)
+      _set(name, object, args)
     end
   end
 

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -129,13 +129,13 @@ class JbuilderTemplate < Jbuilder
     end
   end
 
-  def set!(name, object = BLANK, *args, &block)
+  def set!(name, object = BLANK, *args)
     options = args.first
 
     if _partial_options?(options)
       _set_inline_partial name, object, options
     else
-      _set name, object, args, block
+      ::Kernel.block_given? ? super : _set(name, object, args)
     end
   end
 

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -129,13 +129,13 @@ class JbuilderTemplate < Jbuilder
     end
   end
 
-  def set!(name, object = BLANK, *args)
+  def set!(name, object = BLANK, *args, &block)
     options = args.first
 
-    if args.one? && _partial_options?(options)
+    if _partial_options?(options)
       _set_inline_partial name, object, options
     else
-      super
+      _set name, object, args, &block
     end
   end
 


### PR DESCRIPTION
Similar to #14, but for the `set!` DSL. Many of the changes are similar:
- Save on a call to `one?`. This shows up as a hotspot for us, and it isn't actually needed. The intent here was to check if a single argument was provided to `set!` to determine whether or not a partial should be rendered. It's actually just faster to check if the first argument is a `Hash` than it is to call out to `one?` first, because the latter is an O(n) operation.
- Saves on memory allocations originally caused by an internal call to `Jbuilder::set!` via `super`, which splats `*args` into an allocated `Array` each time. The PR introduces `_set` to be used internally, which saves on this allocation. This is similar to what was done in #7 for `extract!`.

One difference with #14 that is worth noting are how blocks work. Calls to `::Kernel.block_given?` _do_ show up as a hotspot in some of our profiles, which can be optimized away with a simpler `if block` style check. This makes sense given that methods were already receiving a `&block` parameter. While iteratively benchmarking this branch, I learned that simply having a `&block` parameter incurs overhead, regardless of whether or not a block is provided:
- If no block is provided, simply having `&block` in the method introduced extra latency even though `block` would evaluate to `nil`. I'm unsure of the reason why, but I presume Ruby has to do some extra work here to determine what the value of `&block` should be.
- If a block was provided, `&block` would also result in extra memory allocation when converting the block to a `Proc`. While the number of allocations would be the same, the `Proc` resulted in an increase in memsize

Ultimately it was cheaper to keep `&block` out of the method signatures and determine behaviour via `::Kernel.block_given?`. I can revisit the work done in #14 and do the same.

I will annotate some other points of interest below.

Benchmarks for the affected DSLs are below. We see an improvement in all of them!!! (I will commit these with the PR soon).

---

```ruby
json.set! :foo, :bar
```

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
              before   442.412k i/100ms
               after   715.531k i/100ms
Calculating -------------------------------------
              before      5.169M (± 2.3%) i/s  (193.48 ns/i) -     26.102M in   5.053092s
               after      8.678M (± 1.9%) i/s  (115.23 ns/i) -     43.647M in   5.031269s

Comparison:
               after:  8678428.8 i/s
              before:  5168538.2 i/s - 1.68x  slower
```

```
Calculating -------------------------------------
              before    80.000  memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
               after    40.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
               after:         40 allocated
              before:         80 allocated - 2.00x more
```

---

```ruby
# Where object = { bar: 123 }
json.set! :foo do
  json.extract! object, :bar
end
```

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
              before   150.176k i/100ms
               after   179.919k i/100ms
Calculating -------------------------------------
              before      1.553M (± 2.5%) i/s  (643.85 ns/i) -      7.809M in   5.031098s
               after      1.904M (± 1.5%) i/s  (525.19 ns/i) -      9.536M in   5.009223s

Comparison:
               after:  1904088.4 i/s
              before:  1553160.1 i/s - 1.23x  slower
```

```
Calculating -------------------------------------
              before   280.000  memsize (   160.000  retained)
                         4.000  objects (     1.000  retained)
                         0.000  strings (     0.000  retained)
               after   240.000  memsize (   160.000  retained)
                         3.000  objects (     1.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
               after:        240 allocated
              before:        280 allocated - 1.17x more
```

---

```ruby
# Where array = [1, 2, 3]
json.set! :foo, array do |item|
  json.set! :bar, item
end
```

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
              before    76.501k i/100ms
               after   104.594k i/100ms
Calculating -------------------------------------
              before    823.493k (± 2.2%) i/s    (1.21 μs/i) -      4.131M in   5.019101s
               after      1.085M (± 4.0%) i/s  (921.32 ns/i) -      5.439M in   5.020763s

Comparison:
               after:  1085397.8 i/s
              before:   823492.8 i/s - 1.32x  slower
```

```
Calculating -------------------------------------
              before   920.000  memsize (   520.000  retained)
                        14.000  objects (     4.000  retained)
                         0.000  strings (     0.000  retained)
               after   760.000  memsize (   520.000  retained)
                        10.000  objects (     4.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
               after:        760 allocated
              before:        920 allocated - 1.21x more
```

---

```ruby
json.set! :post, post, partial: "post", as: :post
```

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
              before   111.485k i/100ms
               after   125.542k i/100ms
Calculating -------------------------------------
              before      1.138M (± 6.6%) i/s  (879.02 ns/i) -      5.686M in   5.027195s
               after      1.354M (± 1.2%) i/s  (738.83 ns/i) -      6.779M in   5.009416s

Comparison:
               after:  1353500.4 i/s
              before:  1137626.0 i/s - 1.19x  slower
```

```
Calculating -------------------------------------
              before   837.923k memsize (    40.633k retained)
                         3.495k objects (   412.000  retained)
                        50.000  strings (    50.000  retained)
               after   837.923k memsize (    40.633k retained)
                         3.495k objects (   412.000  retained)
                        50.000  strings (    50.000  retained)

Comparison:
              before:     837923 allocated
               after:     837923 allocated - same
```