### PR TITLE
Optimize `array!` DSL (Round 2)

### DIFF
--- a/benchmarks/jbuilder_template/array_dsl.rb
+++ b/benchmarks/jbuilder_template/array_dsl.rb
@@ -7,14 +7,13 @@ require_relative '../../lib/jbuilder/jbuilder_template'
 
 Post = Struct.new(:id, :body)
 json = JbuilderTemplate.new nil
-posts = 3.times.map { Post.new(it, "Post ##{it}") }
 
 Benchmark.ips do |x|
-  x.report('before') do
-    json.array!(nil)
+  x.report('before') do |n|
+    n.times { json.array! }
   end
-  x.report('after') do
-    json.array!(nil)
+  x.report('after') do |n|
+    n.times { json.array! }
   end
 
   x.hold! 'temp_array_ips'
@@ -24,8 +23,8 @@ end
 json = JbuilderTemplate.new nil
 
 Benchmark.memory do |x|
-  x.report('before') { json.array! posts, :id, :body }
-  x.report('after') { json.array! posts, :id, :body }
+  x.report('before') { json.array! }
+  x.report('after') { json.array! }
 
   x.hold! 'temp_array_memory'
   x.compare!

--- a/benchmarks/jbuilder_template/array_dsl_block.rb
+++ b/benchmarks/jbuilder_template/array_dsl_block.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'benchmark/memory'
+require_relative '../../lib/jbuilder'
+require_relative '../../lib/jbuilder/jbuilder_template'
+
+Post = Struct.new(:id, :body)
+json = JbuilderTemplate.new nil
+array = [1, 2, 3]
+
+Benchmark.ips do |x|
+  x.report('before') do |n|
+    n.times do
+      json.array! array do |item|
+      end
+    end
+  end
+  x.report('after') do |n|
+    n.times do
+      json.array! array do |item|
+      end
+    end
+  end
+
+  x.hold! 'temp_array_ips'
+  x.compare!
+end
+
+json = JbuilderTemplate.new nil
+
+Benchmark.memory do |x|
+  x.report('before') do
+    json.array! array do |item|
+    end
+  end
+  x.report('after') do
+    json.array! array do |item|
+    end
+  end
+
+  x.hold! 'temp_array_memory'
+  x.compare!
+end

--- a/benchmarks/partials/array_dsl.rb
+++ b/benchmarks/partials/array_dsl.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'benchmark/memory'
+require_relative 'setup'
+
+POST_PARTIAL = <<-JBUILDER
+  json.extract! post, :id, :body
+JBUILDER
+
+PARTIALS = { "_post.json.jbuilder" => POST_PARTIAL }
+
+Post = Struct.new(:id, :body)
+
+view = build_view(fixtures: PARTIALS)
+json = JbuilderTemplate.new view
+posts = 3.times.map { Post.new(it, "Post ##{it}") }
+
+Benchmark.ips do |x|
+  x.report('before') do |n|
+    n.times { json.array! posts, partial: "post", as: :post }
+  end
+
+  x.report('after') do |n|
+    n.times { json.array! posts, partial: "post", as: :post }
+  end
+
+  x.hold! 'temp_array_results_ips'
+  x.compare!
+end
+
+json = JbuilderTemplate.new view
+
+Benchmark.memory do |x|
+  x.report('before') do
+    json.array! posts, partial: "post", as: :post
+  end
+
+  x.report('after') do
+    json.array! posts, partial: "post", as: :post
+  end
+
+  x.hold! 'temp_array_results_memory'
+  x.compare!
+end

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -118,14 +118,16 @@ class JbuilderTemplate < Jbuilder
     @cached_root || super
   end
 
-  def array!(collection = EMPTY_ARRAY, *args, &block)
+  def array!(collection = EMPTY_ARRAY, *args)
     options = args.first
 
     if _partial_options?(options)
       options[:collection] = collection
       _render_partial_with_options options
+    elsif ::Kernel.block_given?
+      _array(collection, args) { |x| yield x }
     else
-      _array collection, args, &block
+      _array collection, args
     end
   end
 


### PR DESCRIPTION
Follow up to #14. This adopts some of the block param changes from #15.

Benchmarks below to just test the `array!` DSL both with and without a block in a manner that avoids diluting the change is much as possible.

---
```ruby
json.array!
```

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
              before   695.095k i/100ms
               after   916.521k i/100ms
Calculating -------------------------------------
              before      8.361M (± 2.2%) i/s  (119.61 ns/i) -     42.401M in   5.074102s
               after     12.024M (± 1.5%) i/s   (83.16 ns/i) -     60.490M in   5.031704s

Comparison:
               after: 12024496.6 i/s
              before:  8360774.5 i/s - 1.44x  slower

```

```
Calculating -------------------------------------
              before    40.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
               after    40.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
              before:         40 allocated
               after:         40 allocated - same
```

---

```ruby
# Where array = [1, 2, 3]
json.array! array do |item|
end
```

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
              before   307.043k i/100ms
               after   345.351k i/100ms
Calculating -------------------------------------
              before      3.309M (± 1.6%) i/s  (302.20 ns/i) -     16.580M in   5.011739s
               after      3.761M (± 3.6%) i/s  (265.90 ns/i) -     18.994M in   5.058330s

Comparison:
               after:  3760855.9 i/s
              before:  3309112.8 i/s - 1.14x  slower
```

```
Calculating -------------------------------------
              before   160.000  memsize (    40.000  retained)
                         4.000  objects (     1.000  retained)
                         0.000  strings (     0.000  retained)
               after   160.000  memsize (    40.000  retained)
                         4.000  objects (     1.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
              before:        160 allocated
               after:        160 allocated - same
```

---

```ruby
json.array! posts, partial: "post", as: :post
```

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
              before     1.303k i/100ms
               after     1.595k i/100ms
Calculating -------------------------------------
              before      4.748k (±34.2%) i/s  (210.60 μs/i) -     22.151k in   5.104390s
               after      4.729k (±42.3%) i/s  (211.47 μs/i) -     20.735k in   5.110369s

Comparison:
              before:     4748.2 i/s
               after:     4728.7 i/s - same-ish: difference falls within error
```

```
Calculating -------------------------------------
              before     5.952k memsize (   560.000  retained)
                        80.000  objects (     5.000  retained)
                        15.000  strings (     0.000  retained)
               after     5.952k memsize (   560.000  retained)
                        80.000  objects (     5.000  retained)
                        15.000  strings (     0.000  retained)

Comparison:
              before:       5952 allocated
               after:       5952 allocated - same
```