### PR TITLE
Drop Ruby 3.2 support for `rails_head`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,6 +41,8 @@ jobs:
             gemfile: rails_8_0
           - ruby: '3.1'
             gemfile: rails_head
+          - ruby: '3.2'
+            gemfile: rails_head
           - ruby: '3.4'
             gemfile: rails_7_0
 


### PR DESCRIPTION
Saw tests failing on the upstream `main` branch

<img width="425" height="353" alt="image" src="https://github.com/user-attachments/assets/b403db4a-541f-4b33-86ce-064fc1b2c657" />

Ruby 3.2 support was recently dropped in Rails.